### PR TITLE
Add `pass` to fix a Python syntax error in alphadev.py

### DIFF
--- a/alphadev.py
+++ b/alphadev.py
@@ -783,6 +783,7 @@ class Game(object):
 
   def is_correct(self) -> bool:
     # Whether the current algorithm solves the game.
+    pass
 
   def legal_actions(self) -> Sequence[Action]:
     # Game specific calculation of legal actions.


### PR DESCRIPTION
% [`python3.11 -m ast alphadev.py `](https://docs.python.org/3/library/ast.html#command-line-usage)  # Python is unable to build an abstract syntax tree of this Python program.
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 1736, in <module>
    main()
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 1732, in main
    tree = parse(source, args.infile.name, args.mode, type_comments=args.no_type_comments)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "alphadev.py", line 787
    def legal_actions(self) -> Sequence[Action]:
    ^
IndentationError: expected an indented block after function definition on line 784
```